### PR TITLE
Update pytorch 22.02

### DIFF
--- a/pytorch/build_image.sh
+++ b/pytorch/build_image.sh
@@ -1,4 +1,4 @@
-NVC_TAG=21.08
-NERSC_TAG="ngc-${NVC_TAG}-v2"
+NVC_TAG=22.02
+NERSC_TAG="ngc-${NVC_TAG}-v0"
 
 docker build --build-arg nvc_tag=$NVC_TAG-py3 -t nersc/pytorch:$NERSC_TAG -f Dockerfile .

--- a/pytorch/build_image.sh
+++ b/pytorch/build_image.sh
@@ -1,4 +1,4 @@
 NVC_TAG=22.02
 NERSC_TAG="ngc-${NVC_TAG}-v0"
 
-docker build --build-arg nvc_tag=$NVC_TAG-py3 -t nersc/pytorch:$NERSC_TAG -f Dockerfile .
+docker build --platform linux/amd64 --build-arg nvc_tag=$NVC_TAG-py3 -t nersc/pytorch:$NERSC_TAG -f Dockerfile .

--- a/tensorflow/build_image.sh
+++ b/tensorflow/build_image.sh
@@ -1,4 +1,4 @@
 NVC_TAG=21.08-tf2
 NERSC_TAG="ngc-${NVC_TAG}-v1"
 
-docker build --build-arg nvc_tag=$NVC_TAG-py3 -t nersc/tensorflow:$NERSC_TAG -f Dockerfile .
+docker build --platform linux/amd64 --build-arg nvc_tag=$NVC_TAG-py3 -t nersc/tensorflow:$NERSC_TAG -f Dockerfile .


### PR DESCRIPTION
also adding the platform build flag for linux/amd64, so I can build on my M1 mac.