### PR TITLE
Add einops to pip install

### DIFF
--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -21,5 +21,5 @@ RUN HDF5_MPI=ON CC=mpicc HDF5_DIR=/opt/bin/hdf5 pip install --no-deps --no-binar
 RUN pip install --no-cache-dir \
     ruamel.yaml pyyaml cmake ipympl pillow wandb torchsummary pandas \
     jupyter-server-proxy requests tabulate ray ray[tune] ray[rllib] h5py \
-    opencv-python-headless scikit-image mpi4py deepspeed \
+    opencv-python-headless scikit-image mpi4py deepspeed einops \
     git+https://github.com/NERSC/nersc-tensorboard-helper.git


### PR DESCRIPTION
`einops` seems to be increasingly popular (especially among ViT implementations), and is generally nice for efficient tensor rearranging ops as well as improved code readability.