### PR TITLE
pytorch 23.07 updates

### DIFF
--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -2,7 +2,7 @@ ARG nvc_tag
 FROM nvcr.io/nvidia/pytorch:$nvc_tag
 
 RUN python -m pip install --no-cache-dir -U pip
-RUN apt-get update && apt-get install -y rsync
+RUN apt-get update && apt-get install -y rsync strace
 
 # Install parallel HDF5
 RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_1.tar.gz && \
@@ -16,11 +16,9 @@ RUN wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_1.tar.gz &
 # use pip to install and build h5py on top of parallel hdf5
 RUN HDF5_MPI=ON CC=mpicc HDF5_DIR=/opt/bin/hdf5 pip install --no-deps --no-binary=h5py h5py
 
-
 # install other python stuff necessary
 RUN pip install --no-cache-dir \
     ruamel.yaml pyyaml cmake ipympl pillow wandb torchsummary pandas \
-    jupyter-server-proxy requests tabulate ray ray[tune] ray[rllib] h5py \
-    opencv-python-headless scikit-image mpi4py deepspeed einops \
-    pytorch-lightning ray_lightning \
+    jupyter-server-proxy requests tabulate ray ray[tune] ray[rllib] \
+    scikit-image mpi4py deepspeed einops lightning \
     git+https://github.com/NERSC/nersc-tensorboard-helper.git

--- a/pytorch/build_image.sh
+++ b/pytorch/build_image.sh
@@ -1,4 +1,4 @@
-NVC_TAG=23.04
-NERSC_TAG="ngc-${NVC_TAG}-v0"
+NVC_TAG=23.07
+NERSC_TAG="ngc-${NVC_TAG}-v1"
 
 docker build --platform linux/amd64 --build-arg nvc_tag=$NVC_TAG-py3 -t nersc/pytorch:$NERSC_TAG -f Dockerfile .


### PR DESCRIPTION
Updated to ngc 23.07 for pytorch.

Removed the opencv-headless install, fixing https://github.com/NERSC/nersc-ml-images/issues/7

Moved from pytorch-lightning to just lightning.